### PR TITLE
implemented decompression pass for binary files

### DIFF
--- a/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
@@ -29,13 +29,24 @@ function openAsyncXHR(method, url, options = {}) {
 }
 
 function fetchBinary(url, options = {}) {
+  if (options && options.compression && options.compression !== 'gz') {
+    vtkErrorMacro('Supported algorithms are: [gz]');
+    vtkErrorMacro(`Unkown compression algorithm: ${options.compression}`);
+  }
+  
   return new Promise((resolve, reject) => {
     const xhr = openAsyncXHR('GET', url, options);
 
     xhr.onreadystatechange = (e) => {
       if (xhr.readyState === 4) {
         if (xhr.status === 200 || xhr.status === 0) {
-          resolve(xhr.response);
+          if (options.compression) {
+            resolve(
+              pako.inflate(new Uint8Array(xhr.response), { to: 'arraybuffer' }).buffer
+            );
+          } else {
+            resolve(xhr.response);
+          }
         } else {
           reject({ xhr, e });
         }


### PR DESCRIPTION
When reading binary gzipped files (in my case STL), the compression option has no impact. fetchArray, fetchArray, fetchText all contain handling for compression, but fetchBinary does not.

Was a pretty simple fix to include this for binary as well.